### PR TITLE
Added spaces before and after each folder slash.

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,7 +6,7 @@ interface BreadcrumbsProps {
 }
 
 const Breadcrumbs: FC<BreadcrumbsProps> = ({ className, inputItems }) => {
-  return <div className={className}>{ inputItems.join('/') }</div>;
+  return <div className={className}>{ inputItems.join(' / ') }</div>;
 };
 
 export default Breadcrumbs;

--- a/src/components/Breadcrumbs/__tests__/breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/__tests__/breadcrumbs.test.tsx
@@ -2,13 +2,12 @@ import { render } from "@testing-library/react";
 import Breadcrumbs from "../Breadcrumbs";
 
 describe("Breadcrumbs", () => {
-  it("renders folders and files separated by a forward slash", () => {
+  it("renders folders and files seperated by forward slash and spaces", () => {
     const { queryByText } = render(<Breadcrumbs inputItems={["folder1", "folder2", "file1.txt"]} />);
 
-    expect(queryByText("folder1/folder2/file1.txt")).toBeInTheDocument();
+    expect(queryByText("folder1 / folder2 / file1.txt")).toBeInTheDocument();
   });
 
-  // it.todo("adds a space preceding and proceeding each forward slash");
   // it.todo("renders text in UPPERCASE");
   // it.todo("appends '(root folder)' to the end of folders.");
   // it.todo("appends '(root file)' to the end of files");


### PR DESCRIPTION
This PR is for adding spacing before and after each folder slash in the `Breadcrumbs` component.

![image](https://user-images.githubusercontent.com/80778550/180070148-d99cae1e-19b9-4c6e-b258-5cf14b28e226.png)
