### PR TITLE
Root folder and child folders have the level description at the end of the breadcrumb

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,15 @@ export default function App() {
   return (
     <div>
       <div className="header">
-        <Breadcrumbs className="breadcrumbs" inputItems={["folder1", "folder2", "file1.txt"]} />
+        <Breadcrumbs
+          className="breadcrumbs"
+          inputItems={["folder1", "folder2", "folder3", "file1.txt"]}
+        />
+        <Breadcrumbs className="breadcrumbs" inputItems={["folder1"]} />
+        <Breadcrumbs
+          className="breadcrumbs"
+          inputItems={["folder1", "folder2", "folder3", "folder4"]}
+        />
       </div>
       <div className="body">
         <Folder className="folder" />

--- a/src/components/Breadcrumbs/__tests__/breadcrumbsUtil.test.ts
+++ b/src/components/Breadcrumbs/__tests__/breadcrumbsUtil.test.ts
@@ -1,19 +1,45 @@
-import { formatBreadcrumbs } from '../breadcrumbsUtil';
+import { formatBreadcrumbs } from "../breadcrumbsUtil";
 
-describe('formatBreadcrumb', () => {
-    it('is as function', () => {
-        expect(typeof formatBreadcrumbs).toBe('function');
-    });
+describe("formatBreadcrumb", () => {
+  it("is as function", () => {
+    expect(typeof formatBreadcrumbs).toBe("function");
+  });
 
-    it('returns each string in uppercase', () => {
-        const lowerCaseStrings = ['a', 'b', 'c'];
+  it("returns each string in uppercase", () => {
+    const lowerCaseStrings = ["a", "b", "c"];
 
-        expect(formatBreadcrumbs(lowerCaseStrings)).toMatchObject(['A', 'B', 'C']);
-    });
+    expect(formatBreadcrumbs(lowerCaseStrings)).toMatchObject([
+      "A",
+      "B",
+      "C (level 2 folder)",
+    ]);
+  });
 
-    it('returns extensions in lowercase', () => {
-        const lowerCaseStrings = ['a', 'b.txt', 'c.a.ts'];
+  it("returns extensions in lowercase", () => {
+    const lowerCaseStrings = ["a", "b.txt", "c.a.ts"];
 
-        expect(formatBreadcrumbs(lowerCaseStrings)).toMatchObject(['A', 'B.txt', 'C.A.ts']);
-    });
+    expect(formatBreadcrumbs(lowerCaseStrings)).toMatchObject([
+      "A",
+      "B.txt",
+      "C.A.ts",
+    ]);
+  });
+
+  it("has '(root folder) appended if the user is in the root folder' ", () => {
+    const lowerCaseStrings = ["TestFolder"];
+
+    expect(formatBreadcrumbs(lowerCaseStrings)).toMatchObject([
+      "TESTFOLDER (root folder) ",
+    ]);
+  });
+
+  it("displays the folder level at the end of the breadcrumb when nested ", () => {
+    const lowerCaseStrings = ["TestFolder1", "TestFolder2", "TestFolder3"];
+
+    expect(formatBreadcrumbs(lowerCaseStrings)).toMatchObject([
+      "TESTFOLDER1",
+      "TESTFOLDER2",
+      "TESTFOLDER3 (level 2 folder)",
+    ]);
+  });
 });

--- a/src/components/Breadcrumbs/breadcrumbsUtil.ts
+++ b/src/components/Breadcrumbs/breadcrumbsUtil.ts
@@ -1,14 +1,24 @@
 export const formatBreadcrumbs = (lowerCaseStrings: string[]): string[] => {
-    return lowerCaseStrings.map(fileName => {
-        const splitFileName = fileName.split('.');
+  let folderLevel = 0;
+  return lowerCaseStrings.map((fileName, idx) => {
+    const splitFileName = fileName.split(".");
 
-        if (splitFileName.length === 1) {
-            return fileName.toUpperCase();
-        }
+    if (splitFileName.length === 1) {
+      folderLevel++;
+      if (idx === 0 && idx === lowerCaseStrings.length - 1) {
+        return fileName.toUpperCase() + " (root folder) ";
+      }
+      if (idx === lowerCaseStrings.length - 1) {
+        return fileName.toUpperCase() + ` (level ${folderLevel - 1} folder)`;
+      }
+      return fileName.toUpperCase();
+    }
 
-        const fileExtension = splitFileName[splitFileName.length - 1];
-        const restOfFileName = splitFileName.slice(0, splitFileName.length - 1);
+    const fileExtension = splitFileName[splitFileName.length - 1];
+    const restOfFileName = splitFileName.slice(0, splitFileName.length - 1);
 
-        return `${restOfFileName.map(a => a.toUpperCase()).join('.')}.${fileExtension}`;
-    });
+    return `${restOfFileName
+      .map((a) => a.toUpperCase())
+      .join(".")}.${fileExtension}`;
+  });
 };


### PR DESCRIPTION
The root folder is appended with “(root folder)” at the end.
Child folders are appended with “(level X folder)”, where X is the number of levels deep that the folder is.

<img width="589" alt="Screen Shot 2022-09-09 at 1 28 06 PM" src="https://user-images.githubusercontent.com/89927521/189409904-4843fba5-3705-4eec-abac-0ecf3e903a1e.png">
















